### PR TITLE
A couple of testing fixes

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,4 +1,5 @@
 require 'rubygems'
+gem 'sinatra', '<1.0.0'
 require 'sinatra/base'
 require 'bacon'
 require 'sinatra/test'

--- a/test/test_flash.rb
+++ b/test/test_flash.rb
@@ -64,6 +64,13 @@ describe 'Rack::Flash' do
     new_flash[:foo].should.be.nil
   end
 
+  it 'does not raise an error when session is cleared' do
+    flash = new_flash
+    flash[:foo] = 'bar'
+    @fake_session.clear
+    flash['foo'].should.equal(nil)
+  end
+
   describe 'accessorize option' do
     def new_flash(entries={})
       flash = Rack::Flash::FlashHash.new(@fake_session, :accessorize => [:foo, :fizz])


### PR DESCRIPTION
This restricts the sinatra version when testing to <1.0.0 (the bacon testing support was removed in 1.0).  It also adds a test for the clearing of sessions (already implemented, but no test for it).
