### PR TITLE
Fix when using Rack > 1.3.6

### DIFF
--- a/lib/rack/flash.rb
+++ b/lib/rack/flash.rb
@@ -1,30 +1,30 @@
-module Rack
-  class Builder
-    attr :ins
-    def use(middleware, *args, &block)
-      middleware.instance_variable_set "@rack_builder", self
-      def middleware.rack_builder
-        @rack_builder
-      end
-      @ins << lambda { |app|
-        middleware.new(app, *args, &block)
-      }
-    end
-
-    def run(app)
-      klass = app.class
-      klass.instance_variable_set "@rack_builder", self
-      def klass.rack_builder
-        @rack_builder
-      end
-      @ins << app #lambda { |nothing| app }
-    end
-
-    def leaf_app
-      ins.last
-    end
-  end
-end
+#module Rack
+#  class Builder
+#    attr :ins
+#    def use(middleware, *args, &block)
+#      middleware.instance_variable_set "@rack_builder", self
+#      def middleware.rack_builder
+#        @rack_builder
+#      end
+#      @ins << lambda { |app|
+#        middleware.new(app, *args, &block)
+#      }
+#    end
+#
+#    def run(app)
+#      klass = app.class
+#      klass.instance_variable_set "@rack_builder", self
+#      def klass.rack_builder
+#        @rack_builder
+#      end
+#      @ins << app #lambda { |nothing| app }
+#    end
+#
+#    def leaf_app
+#      ins.last
+#    end
+#  end
+#end
 
 module Rack
   class Flash

--- a/lib/rack/flash.rb
+++ b/lib/rack/flash.rb
@@ -1,31 +1,3 @@
-#module Rack
-#  class Builder
-#    attr :ins
-#    def use(middleware, *args, &block)
-#      middleware.instance_variable_set "@rack_builder", self
-#      def middleware.rack_builder
-#        @rack_builder
-#      end
-#      @ins << lambda { |app|
-#        middleware.new(app, *args, &block)
-#      }
-#    end
-#
-#    def run(app)
-#      klass = app.class
-#      klass.instance_variable_set "@rack_builder", self
-#      def klass.rack_builder
-#        @rack_builder
-#      end
-#      @ins << app #lambda { |nothing| app }
-#    end
-#
-#    def leaf_app
-#      ins.last
-#    end
-#  end
-#end
-
 module Rack
   class Flash
     # Raised when the session passed to FlashHash initialize is nil. This

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,9 +1,8 @@
 require 'rubygems'
-gem 'sinatra', '<1.0.0'
+gem 'sinatra', '<=1.3.2'
 require 'sinatra/base'
 require 'bacon'
-require 'sinatra/test'
-require 'sinatra/test/bacon'
+require 'rack/test'
 require File.join(File.dirname(__FILE__), *%w[.. lib rack-flash])
 
 class String
@@ -19,10 +18,6 @@ def err_explain
     puts e.backtrace
     raise e
   end
-end
-
-def mock_app(&block)
-  @app = Sinatra.new(&block)
 end
 
 module Rack

--- a/test/test_flash.rb
+++ b/test/test_flash.rb
@@ -1,6 +1,12 @@
 require File.dirname(__FILE__) + '/helper'
 
 describe 'Rack::Flash' do
+  include Rack::Test::Methods
+
+  def app(&block)
+    return Sinatra.new &block
+  end
+
   before do
     @fake_session = {}
   end
@@ -127,7 +133,7 @@ describe 'Rack::Flash' do
 
   describe 'integration' do
     it 'provides :sweep option to clear unused entries' do
-      mock_app {
+      app {
         use Rack::Flash, :sweep => true
 
         set :sessions, true
@@ -139,7 +145,7 @@ describe 'Rack::Flash' do
 
       fake_flash = Rack::FakeFlash.new(:foo => 'bar')
 
-      get '/', :env => { 'x-rack.flash' => fake_flash }
+      get '/', :env=>{ 'x-rack.flash' => fake_flash }
 
       fake_flash.should.be.flagged
       fake_flash.should.be.swept


### PR DESCRIPTION
This patch removes some lines which were causing problems with rack > 1.3.6. It also updates the test so that they work with Sinatra < 1.3.2 instead of < 1.0.

This is a direct fix for issue #8
